### PR TITLE
Update copyingLifted.js

### DIFF
--- a/src/plugins/copying-lifted/copyingLifted.js
+++ b/src/plugins/copying-lifted/copyingLifted.js
@@ -45,7 +45,7 @@ function removeCopyEvent() {
                     }
                 }, false);
 
-            var style = 'body * :not(input):not(textarea){-webkit-user-select:auto!important;-moz-user-select:auto!important;-ms-user-select:auto!important;user-select:auto!important}';
+            var style = 'body, body *:not(input):not(textarea){-webkit-user-select:auto!important;-moz-user-select:auto!important;-ms-user-select:auto!important;user-select:auto!important}';
 
             var stylenode = document.createElement('style');
 


### PR DESCRIPTION
fix(css): restore text selection in direct child elements

- Adjust CSS selector to properly target body and all descendants
- Exclude form controls from selection override
- Add body itself to the selection scope